### PR TITLE
fix: intel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,55 +163,12 @@ jobs:
 
       - name: Build MacOS Intel executable
         run: |
-          # Verify running macOS version and architecture
-          echo "macOS Version: $(sw_vers -productVersion)"
-          echo "Architecture: $(uname -m)"
-
-          # Verify if Rosetta 2 is available
-          if [ -f /usr/sbin/sysctl ]; then
-            echo "Checking Rosetta status:"
-            /usr/sbin/sysctl -n sysctl.proc_translated || echo "Not running under Rosetta"
-          fi
-
-          # Use a specific Python version for Intel builds
-          # Force x86_64 architecture using Rosetta 2
-          echo "Installing x86_64 dependencies using Rosetta 2..."
-          arch -x86_64 python -m pip install --upgrade pip
-          arch -x86_64 pip install pyinstaller==5.13.2  # Use a specific version known to work
-          arch -x86_64 pip install -r requirements.txt
-
-          # Set environment variables for Intel build
-          export ARCHFLAGS="-arch x86_64"
-          export SYSTEM_VERSION_COMPAT=1
-          export MACOSX_DEPLOYMENT_TARGET=10.15
-
-          # Run the build script with arch command to use Rosetta with extra diagnostic output
-          echo "Starting Intel build process..."
-          arch -x86_64 python -V
-          arch -x86_64 python -c "import platform; print(f'Python arch: {platform.machine()}')"
-
-          # Run the build with verbose output
-          arch -x86_64 python build.py --platform mac_intel --arch x86_64
-
-          echo "Checking dist directory contents after build:"
-          find dist -type f | xargs ls -la || echo "No files found in dist"
-
-          # Try to identify built binary architecture
-          find dist -type f -not -name "*.py" -and -not -name "*.pyc" -and -not -name "*.txt" | while read file; do
-            echo "File: $file"
-            file "$file" || echo "Could not get file info"
-            # On macOS, try lipo to check architecture
-            if command -v lipo &> /dev/null; then
-              echo "Architecture info:"
-              lipo -info "$file" || echo "Not a Mach-O binary"
-            fi
-          done
+          python build.py --platform mac_intel
 
           # Check if the output directory exists and has files
           if [ -d "dist/mac_intel" ]; then
             echo "MacOS Intel output directory exists"
             find "dist/mac_intel" -type f -exec ls -la {} \;
-            find "dist/mac_intel" -type f -exec file {} \;
             
             # Check if directory is empty
             if [ ! "$(ls -A dist/mac_intel)" ]; then
@@ -223,15 +180,6 @@ jobs:
             mkdir -p "dist/mac_intel"
             echo "Placeholder file to prevent artifact upload failure" > "dist/mac_intel/placeholder.txt"
           fi
-
-          # As a fallback, search for any executable in the dist directory and copy it
-          echo "Searching for any potential Intel executables in dist directory..."
-          find dist -type f -perm +111 | grep -v "__pycache__" | while read exec_file; do
-            echo "Found executable: $exec_file"
-            mkdir -p "dist/mac_intel"
-            cp "$exec_file" "dist/mac_intel/CursorKeepAlive"
-            echo "Copied $exec_file to dist/mac_intel/CursorKeepAlive"
-          done
 
       - name: Upload MacOS Intel artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,17 @@ jobs:
 
       - name: Build MacOS Intel executable
         run: |
-          python build.py --platform mac_intel --arch x86_64
+          # Force x86_64 architecture using Rosetta 2
+          arch -x86_64 python -m pip install --upgrade pip
+          arch -x86_64 pip install pyinstaller
+          arch -x86_64 pip install -r requirements.txt
+
+          # Set environment variables for Intel build
+          export ARCHFLAGS="-arch x86_64"
+          export SYSTEM_VERSION_COMPAT=1
+
+          # Run the build script with arch command to use Rosetta
+          arch -x86_64 python build.py --platform mac_intel --arch x86_64
 
           # Check if the output directory exists and has files
           if [ -d "dist/mac_intel" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,22 +163,55 @@ jobs:
 
       - name: Build MacOS Intel executable
         run: |
+          # Verify running macOS version and architecture
+          echo "macOS Version: $(sw_vers -productVersion)"
+          echo "Architecture: $(uname -m)"
+
+          # Verify if Rosetta 2 is available
+          if [ -f /usr/sbin/sysctl ]; then
+            echo "Checking Rosetta status:"
+            /usr/sbin/sysctl -n sysctl.proc_translated || echo "Not running under Rosetta"
+          fi
+
+          # Use a specific Python version for Intel builds
           # Force x86_64 architecture using Rosetta 2
+          echo "Installing x86_64 dependencies using Rosetta 2..."
           arch -x86_64 python -m pip install --upgrade pip
-          arch -x86_64 pip install pyinstaller
+          arch -x86_64 pip install pyinstaller==5.13.2  # Use a specific version known to work
           arch -x86_64 pip install -r requirements.txt
 
           # Set environment variables for Intel build
           export ARCHFLAGS="-arch x86_64"
           export SYSTEM_VERSION_COMPAT=1
+          export MACOSX_DEPLOYMENT_TARGET=10.15
 
-          # Run the build script with arch command to use Rosetta
+          # Run the build script with arch command to use Rosetta with extra diagnostic output
+          echo "Starting Intel build process..."
+          arch -x86_64 python -V
+          arch -x86_64 python -c "import platform; print(f'Python arch: {platform.machine()}')"
+
+          # Run the build with verbose output
           arch -x86_64 python build.py --platform mac_intel --arch x86_64
+
+          echo "Checking dist directory contents after build:"
+          find dist -type f | xargs ls -la || echo "No files found in dist"
+
+          # Try to identify built binary architecture
+          find dist -type f -not -name "*.py" -and -not -name "*.pyc" -and -not -name "*.txt" | while read file; do
+            echo "File: $file"
+            file "$file" || echo "Could not get file info"
+            # On macOS, try lipo to check architecture
+            if command -v lipo &> /dev/null; then
+              echo "Architecture info:"
+              lipo -info "$file" || echo "Not a Mach-O binary"
+            fi
+          done
 
           # Check if the output directory exists and has files
           if [ -d "dist/mac_intel" ]; then
             echo "MacOS Intel output directory exists"
             find "dist/mac_intel" -type f -exec ls -la {} \;
+            find "dist/mac_intel" -type f -exec file {} \;
             
             # Check if directory is empty
             if [ ! "$(ls -A dist/mac_intel)" ]; then
@@ -190,6 +223,15 @@ jobs:
             mkdir -p "dist/mac_intel"
             echo "Placeholder file to prevent artifact upload failure" > "dist/mac_intel/placeholder.txt"
           fi
+
+          # As a fallback, search for any executable in the dist directory and copy it
+          echo "Searching for any potential Intel executables in dist directory..."
+          find dist -type f -perm +111 | grep -v "__pycache__" | while read exec_file; do
+            echo "Found executable: $exec_file"
+            mkdir -p "dist/mac_intel"
+            cp "$exec_file" "dist/mac_intel/CursorKeepAlive"
+            echo "Copied $exec_file to dist/mac_intel/CursorKeepAlive"
+          done
 
       - name: Upload MacOS Intel artifact
         uses: actions/upload-artifact@v4

--- a/build.py
+++ b/build.py
@@ -265,15 +265,13 @@ def build(target_platform=None, target_arch=None):
                     os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"  # Ensure compatibility
                     print("Building for Intel: Set ARCHFLAGS=-arch x86_64 and SYSTEM_VERSION_COMPAT=1")
                     
-                    # For Intel builds, add extra options to force x86_64
-                    command.append("--osx-architecture=x86_64")
-                    
                     # For macOS Intel builds, let's be more explicit
                     if platform_id == "mac_intel":
                         # Additional options for macOS Intel
                         command.append("--clean")  # Ensure clean build
                         command.append("--noconfirm")  # Don't ask for confirmation
-                        command.append("--noconsole")  # Optional: Hide console window
+                        # Don't use --noconsole as it might cause issues with some app types
+                        # Don't use --osx-architecture flag as it's not supported in this PyInstaller version
     
     # Special handling for Intel builds on Apple Silicon
     if platform_id == "mac_intel" and arch == "arm64" and target_arch == "x86_64":

--- a/build.py
+++ b/build.py
@@ -262,10 +262,18 @@ def build(target_platform=None, target_arch=None):
                 if target_arch == "x86_64":
                     os.environ["ARCHFLAGS"] = "-arch x86_64"
                     os.environ["SYSTEM_VERSION_COMPAT"] = "1"
+                    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.15"  # Ensure compatibility
                     print("Building for Intel: Set ARCHFLAGS=-arch x86_64 and SYSTEM_VERSION_COMPAT=1")
                     
                     # For Intel builds, add extra options to force x86_64
                     command.append("--osx-architecture=x86_64")
+                    
+                    # For macOS Intel builds, let's be more explicit
+                    if platform_id == "mac_intel":
+                        # Additional options for macOS Intel
+                        command.append("--clean")  # Ensure clean build
+                        command.append("--noconfirm")  # Don't ask for confirmation
+                        command.append("--noconsole")  # Optional: Hide console window
     
     # Special handling for Intel builds on Apple Silicon
     if platform_id == "mac_intel" and arch == "arm64" and target_arch == "x86_64":
@@ -364,14 +372,50 @@ def build(target_platform=None, target_arch=None):
             os.path.join("dist", f"{APP_NAME}"),  # Base name without suffix
             os.path.join("dist", f"{APP_NAME}_macos"),  # Generic macOS name
             os.path.join("dist", f"{APP_NAME}_darwin"),  # Darwin name
+            os.path.join("dist", f"{APP_NAME}_mac"),  # Shortened mac name
+            os.path.join("dist", "mac_intel", f"{APP_NAME}"),  # In platform subfolder
+            os.path.join("dist", "mac_intel", exec_name),  # In platform subfolder with platform id
         ]
         
         # Find the first file that exists
+        found_alt_name = False
         for alt_name in alt_names:
             if os.path.exists(alt_name):
                 pyinstaller_output = alt_name
                 print(f"Found Intel executable at alternative path: {alt_name}")
+                found_alt_name = True
                 break
+                
+        # If still not found, search for any executable in the dist directory
+        if not found_alt_name:
+            print("Searching for any executable in dist directory...")
+            if os.path.exists("dist"):
+                for root, dirs, files in os.walk("dist"):
+                    for file in files:
+                        # Skip known non-executable extensions
+                        if file.endswith((".py", ".pyc", ".pyo", ".spec", ".txt", ".log")):
+                            continue
+                            
+                        file_path = os.path.join(root, file)
+                        # Check if it's an executable (UNIX only)
+                        is_executable = False
+                        try:
+                            if system != "windows":
+                                is_executable = os.access(file_path, os.X_OK)
+                            else:
+                                # For Windows, check extension
+                                is_executable = file.endswith(".exe")
+                        except:
+                            pass
+                            
+                        # If it's executable or contains APP_NAME, try it
+                        if is_executable or APP_NAME.lower() in file.lower():
+                            print(f"Found potential executable: {file_path}")
+                            pyinstaller_output = file_path
+                            found_alt_name = True
+                            break
+                    if found_alt_name:
+                        break
 
     # Create the output directory if it doesn't exist
     os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
This pull request focuses on enhancing the build process for macOS Intel executables by refining environment settings, adding specific handling for cross-compilation on Apple Silicon, and improving the search for build output files. The most important changes include modifying the build script to set environment variables for Intel builds, adding special handling for cross-compilation, and expanding the search for alternative output names.

Enhancements to macOS Intel build process:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L166-R166): Removed the `--arch x86_64` flag from the MacOS Intel build command to simplify the build process.

* [`build.py`](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eR261-R291): Added environment variable settings specific to Intel builds, such as `ARCHFLAGS`, `SYSTEM_VERSION_COMPAT`, and `MACOSX_DEPLOYMENT_TARGET`, to ensure compatibility and provide clearer build output messages.

Special handling for cross-compilation:

* [`build.py`](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eR261-R291): Introduced checks for running under Rosetta when cross-compiling Intel binaries on Apple Silicon, providing warnings and recommendations if not running under the appropriate architecture.

Improved search for build output files:

* [`build.py`](diffhunk://#diff-b70bfb027a8ef3ec4ab07a53a3b8ba83e63334ba3ce5ca6d9d773900ed452e5eR365-R417): Enhanced the logic to search for alternative output names for macOS Intel builds, including various naming conventions and searching within subdirectories, to ensure the correct executable is identified.