### PR TITLE
feat: enhance email verification by checking spam folders

### DIFF
--- a/src/utils/get_email_code.py
+++ b/src/utils/get_email_code.py
@@ -307,7 +307,7 @@ class EmailVerificationHandler:
             return None
             
         except Exception as e:
-            if 'NoneType' in str(e) and "object has no attribute 'split'" in str(e):
+            if isinstance(e, AttributeError) and "'NoneType' object has no attribute 'split'" in str(e):
                 logging.error(getTranslation("none_type_attribute_error"))
                 return None
             logging.error(getTranslation("icloud_imap_operation_failed").format(e))

--- a/src/utils/get_email_code.py
+++ b/src/utils/get_email_code.py
@@ -66,12 +66,168 @@ class EmailVerificationHandler:
         icloud_imap = Config().get_icloud_imap()
         if icloud_imap:
             logging.info(getTranslation("using_icloud_imap"))
+            # First check inbox
             verify_code = self._get_mail_code_by_icloud_imap(icloud_imap)
+            if verify_code:
+                return verify_code
+            
+            # If no code found in inbox, check spam/junk folders
+            logging.info(getTranslation("checking_spam_folders"))
+            verify_code = self._check_spam_folders(icloud_imap)
             if verify_code:
                 return verify_code
         
         return None
     
+    def _check_spam_folders(self, icloud_config):
+        """Check spam and junk folders for verification code
+        
+        Args:
+            icloud_config: iCloud IMAP configuration
+            
+        Returns:
+            str or None: verification code if found
+        """
+        # Common spam/junk folder names in email services
+        spam_folders = ['Junk', 'Spam', 'Bulk Mail', 'Junk E-mail']
+        
+        # Get list of available folders first
+        try:
+            mail = imaplib.IMAP4_SSL(icloud_config['imap_server'], icloud_config['imap_port'])
+            mail.login(icloud_config['imap_user'], icloud_config['imap_pass'])
+            
+            status, folder_list = mail.list()
+            mail.logout()
+            
+            if status != 'OK':
+                logging.error(getTranslation("icloud_folder_list_failed"))
+                return None
+                
+            # Parse folder names from the response
+            available_folders = []
+            for folder_info in folder_list:
+                if isinstance(folder_info, bytes):
+                    parts = folder_info.decode('utf-8', errors='ignore').split('"')
+                    if len(parts) > 1:
+                        folder_name = parts[-2]
+                        available_folders.append(folder_name)
+            
+            # Filter spam folders that actually exist
+            valid_spam_folders = [folder for folder in spam_folders if folder in available_folders]
+            
+            # If no valid spam folders found, try the default list
+            if not valid_spam_folders:
+                valid_spam_folders = spam_folders
+                
+            logging.info(f"Available spam folders: {valid_spam_folders}")
+            
+        except Exception as e:
+            logging.error(getTranslation("icloud_folder_list_failed") + f": {str(e)}")
+            # Continue with the default list if we can't get available folders
+            valid_spam_folders = spam_folders
+        
+        # Check each potential spam folder
+        for folder in valid_spam_folders:
+            try:
+                # Create a new connection for each folder to avoid state issues
+                mail = None
+                try:
+                    mail = imaplib.IMAP4_SSL(icloud_config['imap_server'], icloud_config['imap_port'])
+                    mail.login(icloud_config['imap_user'], icloud_config['imap_pass'])
+                    mail.select(folder)
+                except Exception as e:
+                    logging.error(getTranslation("error_checking_folder").format(folder, f"Failed to select folder: {e}"))
+                    if mail:
+                        try:
+                            mail.logout()
+                        except:
+                            pass
+                    continue  # Try next folder
+                
+                logging.info(getTranslation("checking_folder").format(folder))
+                
+                try:
+                    status, messages = mail.search(None, 'ALL')
+                    if status != 'OK':
+                        logging.error(f"Search failed in folder {folder}: {status}")
+                        mail.logout()
+                        continue  # Try next folder
+                    
+                    # Handle different message types (bytes or string)
+                    if isinstance(messages[0], bytes):
+                        mail_ids = messages[0].split()
+                    elif isinstance(messages[0], str):
+                        mail_ids = messages[0].encode('utf-8').split()
+                    else:
+                        mail_ids = []
+                        
+                    if not mail_ids:
+                        logging.info(f"No emails in folder {folder}")
+                        mail.logout()
+                        continue  # No emails in this folder
+                    
+                    # Check the latest 10 emails in this folder
+                    for i in range(min(10, len(mail_ids))):
+                        mail_id = mail_ids[len(mail_ids) - 1 - i]
+                        try:
+                            status, msg_data = mail.fetch(mail_id, '(BODY[])')
+                        except (EOFError, ConnectionError, socket.error) as e:
+                            logging.error(getTranslation("icloud_imap_fetch_failed").format(e))
+                            break  # Connection issue, try next folder
+                            
+                        if status != 'OK' or not msg_data or not msg_data[0]:
+                            logging.error(getTranslation("icloud_imap_fetch_status_failed").format(status))
+                            continue
+                        
+                        # Safety check for data structure
+                        if not isinstance(msg_data[0], tuple) or len(msg_data[0]) < 2:
+                            logging.error(f"Unexpected message data structure: {msg_data}")
+                            continue
+                            
+                        raw_email = msg_data[0][1]
+                        if not raw_email:
+                            continue
+                            
+                        email_message = email.message_from_bytes(raw_email)
+                        sender = email_message.get('from', '')
+                        recipient = email_message.get('to', '')
+                        
+                        if self.account not in recipient:
+                            continue
+                        if 'no-reply_at_cursor_sh' not in sender:
+                            continue
+                        
+                        body = self._extract_imap_body(email_message)
+                        if body:
+                            # Look for 6-digit verification code
+                            code_match = re.search(r"(?<![a-zA-Z@.])\b\d{6}\b", body)
+                            if code_match:
+                                code = code_match.group()
+                                logging.info(getTranslation("verification_code_found_in_spam").format(code, folder))
+                                
+                                try:
+                                    mail.store(mail_id, '+FLAGS', '\\Deleted')
+                                    mail.expunge()
+                                except Exception as e:
+                                    logging.error(f"Failed to delete message: {e}")
+                                
+                                mail.logout()
+                                return code
+                except Exception as e:
+                    logging.error(getTranslation("error_checking_folder").format(folder, e))
+                
+                # Close the connection for this folder
+                try:
+                    mail.logout()
+                except:
+                    pass
+                    
+            except Exception as e:
+                logging.error(getTranslation("error_checking_folder").format(folder, e))
+                continue  # Try next folder
+        
+        logging.info(getTranslation("no_verification_code_in_spam"))
+        return None
 
     def _get_mail_code_by_icloud_imap(self, icloud_config, retry=0):
         """使用 iCloud IMAP 获取邮件验证码
@@ -151,6 +307,9 @@ class EmailVerificationHandler:
             return None
             
         except Exception as e:
+            if 'NoneType' in str(e) and "object has no attribute 'split'" in str(e):
+                logging.error(getTranslation("none_type_attribute_error"))
+                return None
             logging.error(getTranslation("icloud_imap_operation_failed").format(e))
             return None
 
@@ -161,19 +320,35 @@ class EmailVerificationHandler:
                 content_type = part.get_content_type()
                 content_disposition = str(part.get("Content-Disposition"))
                 if content_type == "text/plain" and "attachment" not in content_disposition:
-                    charset = part.get_content_charset() or 'utf-8'
                     try:
-                        body = part.get_payload(decode=True).decode(charset, errors='ignore')
-                        return body
+                        charset = part.get_content_charset() or 'utf-8'
+                        payload = part.get_payload(decode=True)
+                        
+                        # Handle potential int type payload (error from logs)
+                        if isinstance(payload, int):
+                            logging.error(f"Unexpected payload type (int): {payload}")
+                            continue
+                            
+                        if payload:
+                            body = payload.decode(charset, errors='ignore')
+                            return body
                     except Exception as e:
                         logging.error(getTranslation("email_body_decode_failed").format(e))
         else:
             content_type = email_message.get_content_type()
             if content_type == "text/plain":
-                charset = email_message.get_content_charset() or 'utf-8'
                 try:
-                    body = email_message.get_payload(decode=True).decode(charset, errors='ignore')
-                    return body
+                    charset = email_message.get_content_charset() or 'utf-8'
+                    payload = email_message.get_payload(decode=True)
+                    
+                    # Handle potential int type payload (error from logs)
+                    if isinstance(payload, int):
+                        logging.error(f"Unexpected payload type (int): {payload}")
+                        return ""
+                        
+                    if payload:
+                        body = payload.decode(charset, errors='ignore')
+                        return body
                 except Exception as e:
                     logging.error(getTranslation("email_body_decode_failed").format(e))
         return ""

--- a/src/utils/language.py
+++ b/src/utils/language.py
@@ -175,6 +175,36 @@ class LanguageManager:
                 Language.CHINESE: "获取会话令牌失败，注册流程未完成"
             },
             
+            # Spam folder related translations
+            "checking_spam_folders": {
+                Language.ENGLISH: "Verification code not found in inbox, checking spam/junk folders...",
+                Language.CHINESE: "收件箱中未找到验证码，正在检查垃圾邮件文件夹..."
+            },
+            "icloud_folder_list_failed": {
+                Language.ENGLISH: "Failed to retrieve folder list from iCloud",
+                Language.CHINESE: "无法获取iCloud文件夹列表"
+            },
+            "checking_folder": {
+                Language.ENGLISH: "Checking folder: {0}",
+                Language.CHINESE: "正在检查文件夹: {0}"
+            },
+            "verification_code_found_in_spam": {
+                Language.ENGLISH: "Verification code found in spam: {0} (folder: {1})",
+                Language.CHINESE: "垃圾邮件文件夹中找到验证码: {0} (文件夹: {1})"
+            },
+            "error_checking_folder": {
+                Language.ENGLISH: "Error checking folder {0}: {1}",
+                Language.CHINESE: "检查文件夹 {0} 时出错: {1}"
+            },
+            "no_verification_code_in_spam": {
+                Language.ENGLISH: "No verification code found in spam folders",
+                Language.CHINESE: "垃圾邮件文件夹中未找到验证码"
+            },
+            "spam_folder_check_failed": {
+                Language.ENGLISH: "Spam folder check failed: {0}",
+                Language.CHINESE: "垃圾邮件文件夹检查失败: {0}"
+            },
+            
             # Sign-up process specific
             "filling_personal_info": {
                 Language.ENGLISH: "Filling personal information...",
@@ -845,8 +875,8 @@ class LanguageManager:
                 Language.CHINESE: "获取 iCloud 邮件列表失败: {0}"
             },
             "no_emails_in_icloud": {
-                Language.ENGLISH: "No emails found in iCloud mailbox",
-                Language.CHINESE: "iCloud 邮箱中没有找到邮件"
+                Language.ENGLISH: "No emails found in iCloud folder: {0}",
+                Language.CHINESE: "在iCloud文件夹中没有找到邮件: {0}"
             },
             "icloud_imap_fetch_failed": {
                 Language.ENGLISH: "iCloud IMAP fetch failed: {0}",
@@ -871,6 +901,31 @@ class LanguageManager:
             "email_body_decode_failed": {
                 Language.ENGLISH: "Failed to decode email body: {0}",
                 Language.CHINESE: "解码邮件正文失败: {0}"
+            },
+            "none_type_attribute_error": {
+                Language.ENGLISH: "INBOX is empty, checking other folders",
+                Language.CHINESE: "INBOX是空的，现在检查其他文件夹"
+            },
+            # New IMAP error handling translations
+            "checking_imap_folder": {
+                Language.ENGLISH: "Checking IMAP folder: {0}",
+                Language.CHINESE: "正在检查IMAP文件夹: {0}"
+            },
+            "empty_messages_response": {
+                Language.ENGLISH: "IMAP server returned empty messages response",
+                Language.CHINESE: "IMAP服务器返回了空的邮件响应"
+            },
+            "empty_first_message_item": {
+                Language.ENGLISH: "IMAP server returned empty first message item",
+                Language.CHINESE: "IMAP服务器返回了空的第一条邮件项"
+            },
+            "unexpected_message_type": {
+                Language.ENGLISH: "Unexpected message type from IMAP server: {0}",
+                Language.CHINESE: "IMAP服务器返回了意外的邮件类型: {0}"
+            },
+            "inbox_empty_error": {
+                Language.ENGLISH: "Inbox is empty - no emails in folder: {0}",
+                Language.CHINESE: "收件箱是空的 - 文件夹中没有邮件: {0}"
             },
             # Token refresh translations
             "token_refresh_success": {


### PR DESCRIPTION
This pull request enhances the email verification code retrieval process by adding functionality to check spam/junk folders, improving error handling, and updating translations for better user feedback. The most important changes are grouped by functionality and detailed below.

### Enhancements to Email Code Retrieval:
* Added a new `_check_spam_folders` method to search for verification codes in common spam/junk folders when the inbox does not contain the code. This includes folder validation, iterative folder checking, and handling edge cases like empty or unexpected message structures. (`src/utils/get_email_code.py`)

### Error Handling Improvements:
* Updated `_get_mail_code_by_icloud_imap` to handle specific `NoneType` attribute errors gracefully by logging and returning `None`. (`src/utils/get_email_code.py`)
* Enhanced `_extract_imap_body` to handle unexpected payload types (e.g., integers) and ensure robust decoding of email bodies. (`src/utils/get_email_code.py`)

### Translation Updates:
* Added new translations for spam folder checks, error messages, and IMAP operations, improving multi-language support and user feedback. (`src/utils/language.py`) [[1]](diffhunk://#diff-6a202d224a0fc87430f71977ee0e68da54defe1492f9cbef724dc65716e0df1bR178-R207) [[2]](diffhunk://#diff-6a202d224a0fc87430f71977ee0e68da54defe1492f9cbef724dc65716e0df1bL848-R879) [[3]](diffhunk://#diff-6a202d224a0fc87430f71977ee0e68da54defe1492f9cbef724dc65716e0df1bR905-R929)